### PR TITLE
Adding timestamp to bag file name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(rosbag_fancy
 	${CURSES_LIBRARIES}
 )
 
-# Version 1.5 (increment this comment to trigger a CMake update)
+# Version 1.6 (increment this comment to trigger a CMake update)
 catkin_add_env_hooks(50-rosbag_fancy
 	SHELLS bash
 	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks

--- a/env-hooks/50-rosbag_fancy.bash
+++ b/env-hooks/50-rosbag_fancy.bash
@@ -15,7 +15,7 @@ function _rosbag_fancy() {
 	local cmd="${COMP_WORDS[1]}"
 
 	local FLAGS=( --help )
-	local OPTS=( --topic --queue-size -o --output )
+	local OPTS=( --topic --queue-size -o --output -p --prefix )
 
 	# Are we currently inside an option?
 	if [[ " ${OPTS[@]} " =~ " ${COMP_WORDS[COMP_CWORD-1]} " ]]; then

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv)
 			timeToString(ros::Time::now())
 		);
 	}
-	ROSFMT_INFO("Bagfile name: %s", bagName); 
+	ROSFMT_INFO("Bagfile name: {}", bagName);
 
 	try
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,17 +14,15 @@
 #include "terminal.h"
 #include "topic_subscriber.h"
 #include "ui.h"
-#include <iomanip>
 
 namespace po = boost::program_options;
 
-std::string timeToString ( const ros::Time & cur_ros_t )
+std::string timeToString(const ros::Time& cur_ros_t)
 {
 	std::time_t cur_t = cur_ros_t.sec;
-	std::tm cur_tm = *std::localtime( & cur_t );
-	std::stringstream cur_ts;
-	cur_ts << std::put_time(&cur_tm, "%Y-%m-%d-%H-%M-%S");
-	return cur_ts.str();
+	std::stringstream ss;
+	ss << std::put_time(std::localtime(&cur_t), "%Y-%m-%d-%H-%M-%S");
+	return ss.str();
 }
 
 int main(int argc, char** argv)
@@ -116,17 +114,17 @@ int main(int argc, char** argv)
 	BagWriter writer{queue};
 
 	std::string bagName = "";
-	if ( vm.count("output") )
+	if(vm.count("output"))
 	{
 		bagName = vm["output"].as<std::string>();
 	}
 	else
 	{
-		if ( vm.count("prefix") )
+		if(vm.count("prefix"))
 		{
 			bagName = vm["prefix"].as<std::string>();
 		}
-		bagName = bagName + "_"+ timeToString(ros::Time::now()) + ".bag";
+		bagName = bagName + "_" + timeToString(ros::Time::now()) + ".bag";
 	}
 	ROSFMT_INFO("Bagfile name: %s", bagName); 
 


### PR DESCRIPTION
Added feature to set either prefix for target bag file appended by the current time stamp as in rosbag or use the specified bag file. If neither nor is defined, the current time stamp is used as the bag name.